### PR TITLE
WIP: Add pathogen generate command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,16 +10,25 @@
 		"Other"
 	],
 	"activationEvents": [
-		"onCommand:vscode-pathogen.helloWorld"
+		"onCommand:extension.pathogen.generate"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
 		"commands": [
 			{
-				"command": "vscode-pathogen.helloWorld",
-				"title": "Hello World"
+				"command": "extension.pathogen.generate",
+				"title": "Generate with Pathogen"
 			}
-		]
+		],
+		"menus": {
+			"explorer/context": [
+				{
+					"command": "extension.pathogen.generate",
+					"group": "pathogen",
+					"when": "explorerResourceIsFolder"
+				}
+			]
+		}
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,0 +1,23 @@
+"use strict";
+
+import process = require('child_process');
+import vscode = require('vscode');
+
+export async function run(args: any) {
+
+    const destination = args ? args.fsPath : vscode.workspace.rootPath;
+
+    const remote = await vscode.window.showInputBox({ prompt: "Enter the pathogen template repository" });
+
+    if (remote === undefined) {
+        console.error('undefined remote template repository');
+        return;
+    }
+
+    const generate = process.spawn('pathogen', ['generate', remote, destination]);
+
+    generate.stdout.on('data', async (data: any) => {
+        let value = await vscode.window.showInputBox({ prompt: data.toString().replace(/:$/, '') });
+        generate.stdin.write(`${value}\n`);
+    });
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,27 +1,10 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
+'use strict';
+
 import * as vscode from 'vscode';
+import Generate = require('./commands/generate');
 
-// this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "vscode-pathogen" is now active!');
-
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with registerCommand
-	// The commandId parameter must match the command field in package.json
-	let disposable = vscode.commands.registerCommand('vscode-pathogen.helloWorld', () => {
-		// The code you place here will be executed every time your command is executed
-
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from vscode-pathogen!');
-	});
-
-	context.subscriptions.push(disposable);
+	context.subscriptions.push(vscode.commands.registerCommand('extension.pathogen.generate', Generate.run));
 }
 
-// this method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import Generate = require('./commands/generate');
+import * as commands from './commands/generate';
 
 export function activate(context: vscode.ExtensionContext) {
-	context.subscriptions.push(vscode.commands.registerCommand('extension.pathogen.generate', Generate.run));
+	context.subscriptions.push(vscode.commands.registerCommand('extension.pathogen.generate', commands.Generate(context)));
 }
 
 export function deactivate() { }


### PR DESCRIPTION
@justincely, @kaitmore, @tilleryd, this was pretty easy actually.  The behavior as of now is:

1. Adds a "Generate with Pathogen" command.
1. Adds a "Generate with Pathogen" context menu to directory objects in the "Explorer" view.
1. When either of the above are selected, prompts the user for a remote template source and then interactively resolves the input variables and generates using pathogen.